### PR TITLE
Fix bug with MarioParty2E SFX banks

### DIFF
--- a/N64 Sound Tool/N64SoundListToolUpdated/N64SoundLibrary/N64AIFCAudio.cpp
+++ b/N64 Sound Tool/N64SoundListToolUpdated/N64SoundLibrary/N64AIFCAudio.cpp
@@ -23389,12 +23389,10 @@ ALBank* CN64AIFCAudio::ReadAudioMarioParty2E(unsigned char* ROM, unsigned char* 
 
 		int x = 0;
 		{
-			alBank->inst[x]->soundCount = CharArrayToShort(&ctl[bankOffset-2]) / 0x10;
-			if (alBank->inst[x]->soundCount == 0x0000)
-			{
-				// Mario Party
-				alBank->inst[x]->soundCount = CharArrayToLong(&ctl[bankOffset]) / 0x10;
-			}
+			// Mario Party
+			// Technically this is the size of the data, but each item is 0x10 bytes long
+			// so we can cheat and use that as the size of the array count
+			alBank->inst[x]->soundCount = CharArrayToLong(&ctl[bankOffset]) / 0x10;
 			alBank->inst[x]->sounds = new ALSound*[alBank->inst[x]->soundCount];
 
 			for (int y = 0; y < alBank->inst[x]->soundCount; y++)


### PR DESCRIPTION
MarioParty2E SBF0 banks had a bug where far less than the correct number of sound effects were viewable/dumpable if they were using the format that Mario Party 2 and Mario Party 3 use for their SBF0 banks.  This doesn't seem to affect any other games that used this format besides specifically Mario Party 2 and 3, because the previous check was whether the halfword before the start of the data was nonzero, which in Mario Party 1's case (and likely other games' too) it was zero, so the correct data was used instead.

I tested this patch in a version of the project converted to compile in Visual Studio 2017, but only submitted the patched file without the changes to make it VS2017 compatible.